### PR TITLE
Fix GameComponentDef field usage

### DIFF
--- a/Defs/GameComponentDefs/GameComponents.xml
+++ b/Defs/GameComponentDefs/GameComponents.xml
@@ -2,6 +2,6 @@
 <Defs>
   <GameComponentDef>
     <defName>WalkBarefootDamage</defName>
-    <class>WalkAMileInMyShoes.GameComponent_BarefootDamage</class>
+    <gameComponentClass>WalkAMileInMyShoes.GameComponent_BarefootDamage</gameComponentClass>
   </GameComponentDef>
 </Defs>


### PR DESCRIPTION
## Summary
- correctly reference the barefoot damage game component in `GameComponents.xml`

## Testing
- `dotnet build Source/WalkAMileInMyShoes.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689335cd7bdc83258ef841cd7732acf9