### PR TITLE
Refactor barefoot damage initialization

### DIFF
--- a/Defs/GameComponentDefs/BarefootDamage.xml
+++ b/Defs/GameComponentDefs/BarefootDamage.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Defs>
-  <GameComponentDef>
-    <defName>WalkBarefootDamage</defName>
-    <componentClass>WalkAMileInMyShoes.GameComponent_BarefootDamage</componentClass>
-  </GameComponentDef>
-</Defs>

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Place this folder in your RimWorld `Mods` directory to play.
 ### Development
 Game libraries such as `Assembly-CSharp.dll` are only required for building the mod
 and should not be included in the published `Mods` folder. Keeping them out of the
-mod directory prevents type loading conflicts like missing `GameComponentDef` errors.
+mod directory prevents type loading conflicts when the game starts.

--- a/Source/Bootstrap.cs
+++ b/Source/Bootstrap.cs
@@ -1,0 +1,26 @@
+using HarmonyLib;
+using Verse;
+
+namespace WalkAMileInMyShoes
+{
+    [StaticConstructorOnStartup]
+    public static class Bootstrap
+    {
+        static Bootstrap()
+        {
+            var harmony = new Harmony("openai.walkamileinmyshoes");
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Game), nameof(Game.FinalizeInit)),
+                postfix: new HarmonyMethod(typeof(Bootstrap), nameof(AddComponent))
+            );
+        }
+
+        private static void AddComponent(Game __instance)
+        {
+            if (__instance.GetComponent<GameComponent_BarefootDamage>() == null)
+            {
+                __instance.components.Add(new GameComponent_BarefootDamage(__instance));
+            }
+        }
+    }
+}

--- a/Source/WalkAMileInMyShoes.csproj
+++ b/Source/WalkAMileInMyShoes.csproj
@@ -18,5 +18,9 @@
       <HintPath>../Libraries/UnityEngine.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="0Harmony">
+      <HintPath>../Libraries/0Harmony.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Dynamically add barefoot damage component at game init via Harmony patch instead of GameComponentDef
- Reference Harmony library in project file
- Clarify development notes about excluding game libraries from mod package

## Testing
- `dotnet build` *(fails: RimWorld, Verse, and Harmony libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_689348150694832595f7fbd0c17259ab